### PR TITLE
[nit] rm whitespace at EOL

### DIFF
--- a/MAINTAINERS_GUIDE.md
+++ b/MAINTAINERS_GUIDE.md
@@ -50,7 +50,7 @@ All decisions affecting runc, big and small, follow the same 3 steps:
 
 * Step 2: Discuss the pull request. Anyone can do this.
 
-* Step 3: Accept (`LGTM`) or refuse a pull request. The relevant maintainers do 
+* Step 3: Accept (`LGTM`) or refuse a pull request. The relevant maintainers do
 this (see below "Who decides what?")
 
 *I'm a maintainer, should I make pull requests too?*

--- a/NOTICE
+++ b/NOTICE
@@ -8,9 +8,9 @@ The following is courtesy of our legal counsel:
 
 
 Use and transfer of Docker may be subject to certain restrictions by the
-United States and other governments.  
+United States and other governments.
 It is your responsibility to ensure that your use and/or transfer does not
-violate applicable laws. 
+violate applicable laws.
 
 For more information, please see http://www.bis.doc.gov
 

--- a/contrib/completions/bash/runc
+++ b/contrib/completions/bash/runc
@@ -382,7 +382,7 @@ _runc_events() {
 _runc_list() {
 	local boolean_options="
 	   --help
-	   --quiet 
+	   --quiet
 	   -q
 	"
 

--- a/libcontainer/SPEC.md
+++ b/libcontainer/SPEC.md
@@ -2,7 +2,7 @@
 
 This is the standard configuration for version 1 containers.  It includes
 namespaces, standard filesystem setup, a default Linux capability set, and
-information about resource reservations.  It also has information about any 
+information about resource reservations.  It also has information about any
 populated environment settings for the processes running inside a container.
 
 Along with the configuration of how a container is created the standard also
@@ -42,10 +42,10 @@ the binaries and system libraries are local to that directory.  Any binaries
 to be executed must be contained within this rootfs.
 
 Mounts that happen inside the container are automatically cleaned up when the
-container exits as the mount namespace is destroyed and the kernel will 
+container exits as the mount namespace is destroyed and the kernel will
 unmount all the mounts that were setup within that namespace.
 
-For a container to execute properly there are certain filesystems that 
+For a container to execute properly there are certain filesystems that
 are required to be mounted within the rootfs that the runtime will setup.
 
 |     Path    |  Type  |                  Flags                 |                 Data                     |
@@ -58,7 +58,7 @@ are required to be mounted within the rootfs that the runtime will setup.
 | /sys        | sysfs  | MS_NOEXEC,MS_NOSUID,MS_NODEV,MS_RDONLY |                                          |
 
 
-After a container's filesystems are mounted within the newly created 
+After a container's filesystems are mounted within the newly created
 mount namespace `/dev` will need to be populated with a set of device nodes.
 It is expected that a rootfs does not need to have any device nodes specified
 for `/dev` within the rootfs as the container will setup the correct devices
@@ -76,25 +76,25 @@ that are required for executing a container's process.
 
 **ptmx**
 `/dev/ptmx` will need to be a symlink to the host's `/dev/ptmx` within
-the container.  
+the container.
 
 The use of a pseudo TTY is optional within a container and it should support both.
-If a pseudo is provided to the container `/dev/console` will need to be 
+If a pseudo is provided to the container `/dev/console` will need to be
 setup by binding the console in `/dev/` after it has been populated and mounted
 in tmpfs.
 
 |      Source     | Destination  | UID GID | Mode | Type |
 | --------------- | ------------ | ------- | ---- | ---- |
-| *pty host path* | /dev/console | 0 0     | 0600 | bind | 
+| *pty host path* | /dev/console | 0 0     | 0600 | bind |
 
 
 After `/dev/null` has been setup we check for any external links between
 the container's io, STDIN, STDOUT, STDERR.  If the container's io is pointing
-to `/dev/null` outside the container we close and `dup2` the `/dev/null` 
+to `/dev/null` outside the container we close and `dup2` the `/dev/null`
 that is local to the container's rootfs.
 
 
-After the container has `/proc` mounted a few standard symlinks are setup 
+After the container has `/proc` mounted a few standard symlinks are setup
 within `/dev/` for the io.
 
 |    Source       | Destination |
@@ -104,7 +104,7 @@ within `/dev/` for the io.
 | /proc/self/fd/1 | /dev/stdout |
 | /proc/self/fd/2 | /dev/stderr |
 
-A `pivot_root` is used to change the root for the process, effectively 
+A `pivot_root` is used to change the root for the process, effectively
 jailing the process inside the rootfs.
 
 ```c
@@ -151,7 +151,7 @@ so that containers can be paused and resumed.
 
 The parent process of the container's init must place the init pid inside
 the correct cgroups before the initialization begins.  This is done so
-that no processes or threads escape the cgroups.  This sync is 
+that no processes or threads escape the cgroups.  This sync is
 done via a pipe ( specified in the runtime section below ) that the container's
 init process will block waiting for the parent to finish setup.
 
@@ -263,7 +263,7 @@ For example, on a two-socket machine, the schema line could be
 "MB:0=5000;1=7000" which means 5000 MBps memory bandwidth limit on socket 0
 and 7000 MBps memory bandwidth limit on socket 1.
 
-For more information about Intel RDT kernel interface:  
+For more information about Intel RDT kernel interface:
 https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt
 
 ```
@@ -285,7 +285,7 @@ maximum memory bandwidth of 20% on socket 0 and 70% on socket 1.
 }
 ```
 
-### Security 
+### Security
 
 The standard set of Linux capabilities that are set in a container
 provide a good default for security and flexibility for the applications.
@@ -335,8 +335,8 @@ provide a good default for security and flexibility for the applications.
 
 Additional security layers like [apparmor](https://wiki.ubuntu.com/AppArmor)
 and [selinux](http://selinuxproject.org/page/Main_Page) can be used with
-the containers.  A container should support setting an apparmor profile or 
-selinux process and mount labels if provided in the configuration.  
+the containers.  A container should support setting an apparmor profile or
+selinux process and mount labels if provided in the configuration.
 
 Standard apparmor profile:
 ```c
@@ -371,17 +371,17 @@ profile <profile_name> flags=(attach_disconnected,mediate_deleted) {
 
 ### Runtime and Init Process
 
-During container creation the parent process needs to talk to the container's init 
+During container creation the parent process needs to talk to the container's init
 process and have a form of synchronization.  This is accomplished by creating
-a pipe that is passed to the container's init.  When the init process first spawns 
+a pipe that is passed to the container's init.  When the init process first spawns
 it will block on its side of the pipe until the parent closes its side.  This
-allows the parent to have time to set the new process inside a cgroup hierarchy 
-and/or write any uid/gid mappings required for user namespaces.  
+allows the parent to have time to set the new process inside a cgroup hierarchy
+and/or write any uid/gid mappings required for user namespaces.
 The pipe is passed to the init process via FD 3.
 
 The application consuming libcontainer should be compiled statically.  libcontainer
 does not define any init process and the arguments provided are used to `exec` the
-process inside the application.  There should be no long running init within the 
+process inside the application.  There should be no long running init within the
 container spec.
 
 If a pseudo tty is provided to a container it will open and `dup2` the console
@@ -391,10 +391,10 @@ as `/dev/console`.
 An extra set of mounts are provided to a container and setup for use.  A container's
 rootfs can contain some non portable files inside that can cause side effects during
 execution of a process.  These files are usually created and populated with the container
-specific information via the runtime.  
+specific information via the runtime.
 
 **Extra runtime files:**
-* /etc/hosts 
+* /etc/hosts
 * /etc/resolv.conf
 * /etc/hostname
 * /etc/localtime
@@ -407,7 +407,7 @@ these apply to processes within a container.
 
 |       Type          |             Value              |
 | ------------------- | ------------------------------ |
-| Parent Death Signal | SIGKILL                        | 
+| Parent Death Signal | SIGKILL                        |
 | UID                 | 0                              |
 | GID                 | 0                              |
 | GROUPS              | 0, NULL                        |
@@ -420,15 +420,15 @@ these apply to processes within a container.
 ## Actions
 
 After a container is created there is a standard set of actions that can
-be done to the container.  These actions are part of the public API for 
+be done to the container.  These actions are part of the public API for
 a container.
 
 |     Action     |                         Description                                |
 | -------------- | ------------------------------------------------------------------ |
-| Get processes  | Return all the pids for processes running inside a container       | 
+| Get processes  | Return all the pids for processes running inside a container       |
 | Get Stats      | Return resource statistics for the container as a whole            |
 | Wait           | Waits on the container's init process ( pid 1 )                    |
-| Wait Process   | Wait on any of the container's processes returning the exit status | 
+| Wait Process   | Wait on any of the container's processes returning the exit status |
 | Destroy        | Kill the container's init process and remove any filesystem state  |
 | Signal         | Send a signal to the container's init process                      |
 | Signal Process | Send a signal to any of the container's processes                  |

--- a/libcontainer/nsenter/README.md
+++ b/libcontainer/nsenter/README.md
@@ -1,15 +1,15 @@
 ## nsenter
 
-The `nsenter` package registers a special init constructor that is called before 
-the Go runtime has a chance to boot.  This provides us the ability to `setns` on 
-existing namespaces and avoid the issues that the Go runtime has with multiple 
-threads.  This constructor will be called if this package is registered, 
+The `nsenter` package registers a special init constructor that is called before
+the Go runtime has a chance to boot.  This provides us the ability to `setns` on
+existing namespaces and avoid the issues that the Go runtime has with multiple
+threads.  This constructor will be called if this package is registered,
 imported, in your go application.
 
 The `nsenter` package will `import "C"` and it uses [cgo](https://golang.org/cmd/cgo/)
-package. In cgo, if the import of "C" is immediately preceded by a comment, that comment, 
+package. In cgo, if the import of "C" is immediately preceded by a comment, that comment,
 called the preamble, is used as a header when compiling the C parts of the package.
-So every time we  import package `nsenter`, the C code function `nsexec()` would be 
+So every time we  import package `nsenter`, the C code function `nsexec()` would be
 called. And package `nsenter` is only imported in `init.go`, so every time the runc
 `init` command is invoked, that C code is run.
 

--- a/man/runc-delete.8.md
+++ b/man/runc-delete.8.md
@@ -14,6 +14,6 @@ Where "`<container-id>`" is the name for the instance of the container.
 # EXAMPLE
 For example, if the container id is "ubuntu01" and runc list currently shows the
 status of "ubuntu01" as "stopped" the following will delete resources held for
-"ubuntu01" removing "ubuntu01" from the runc list of containers:  
+"ubuntu01" removing "ubuntu01" from the runc list of containers:
 
        # runc delete ubuntu01

--- a/man/runc-pause.8.md
+++ b/man/runc-pause.8.md
@@ -7,7 +7,7 @@
    runc pause `<container-id>`
 
 Where "`<container-id>`" is the name for the instance of the container to be
-paused. 
+paused.
 
 # DESCRIPTION
    The pause command suspends all processes in the instance of the container.

--- a/man/runc.8.md
+++ b/man/runc.8.md
@@ -5,7 +5,7 @@
 
 # SYNOPSIS
    runc [global options] command [command options] [arguments...]
-   
+
 # DESCRIPTION
 runc is a command line client for running applications packaged according to
 the Open Container Initiative (OCI) format and is a compliant implementation of the
@@ -18,7 +18,7 @@ direct child of the process supervisor.
 
 Containers are configured using bundles. A bundle for a container is a directory
 that includes a specification file named "config.json" and a root filesystem.
-The root filesystem contains the contents of the container. 
+The root filesystem contains the contents of the container.
 
 To start a new instance of a container:
 
@@ -48,7 +48,7 @@ value for "bundle" is the current directory.
     state        output the state of a container
     update       update container resource constraints
     help, h      Shows a list of commands or help for one command
-   
+
 # GLOBAL OPTIONS
     --debug              enable debug output for logging
     --log value          set the log file path where internal debug information is written (default: "/dev/null")

--- a/script/.validate
+++ b/script/.validate
@@ -3,23 +3,23 @@
 if [ -z "$VALIDATE_UPSTREAM" ]; then
 	# this is kind of an expensive check, so let's not do this twice if we
 	# are running more than one validate bundlescript
-	
+
 	VALIDATE_REPO='https://github.com/opencontainers/runc.git'
 	VALIDATE_BRANCH='master'
-	
+
 	if [ "$TRAVIS" = 'true' -a "$TRAVIS_PULL_REQUEST" != 'false' ]; then
 		VALIDATE_REPO="https://github.com/${TRAVIS_REPO_SLUG}.git"
 		VALIDATE_BRANCH="${TRAVIS_BRANCH}"
 	fi
-	
+
 	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
-	
+
 	git fetch -q "$VALIDATE_REPO" "refs/heads/$VALIDATE_BRANCH"
 	VALIDATE_UPSTREAM="$(git rev-parse --verify FETCH_HEAD)"
-	
+
 	VALIDATE_COMMIT_LOG="$VALIDATE_UPSTREAM..$VALIDATE_HEAD"
 	VALIDATE_COMMIT_DIFF="$VALIDATE_UPSTREAM...$VALIDATE_HEAD"
-	
+
 	validate_diff() {
 		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
 			git diff "$VALIDATE_COMMIT_DIFF" "$@"

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -22,7 +22,7 @@ function teardown() {
 }
 
 @test "runc run [ro tmpfs mount]" {
-	update_config ' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}] 
+	update_config ' .mounts += [{"source": "tmpfs", "destination": "/mnt", "type": "tmpfs", "options": ["ro", "nodev", "nosuid", "mode=755"]}]
 			| .process.args |= ["grep", "^tmpfs /mnt", "/proc/mounts"]'
 
 	runc run test_ro_tmpfs_mount


### PR DESCRIPTION
Mostly found by `git grep '\s$' | grep -v ^vendor/`

(actually just testing travis-ci integration)