### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Dependencies listed in go.mod
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  # Dependencies listed in .github/workflows/*.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Dependencies listed in Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should enable a bot that auto-creates PRs to update dependencies.

For more info, see
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

Once enabled, dependabot work should be seen at
https://github.com/opencontainers/runc/network/updates
(as well as new PRs).

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>