### PR TITLE
TEST: shellcheck problem matcher experiment (do not merge)

### DIFF
--- a/.github/shellcheck-tty.json
+++ b/.github/shellcheck-tty.json
@@ -2,6 +2,7 @@
   "problemMatcher": [
     {
       "owner": "shellcheck-tty",
+      "severity": "error",
       "pattern": [
         {
           "regexp": "^In\\s(.+)\\sline\\s(\\d+):$",
@@ -12,10 +13,9 @@
           "regexp": ".*"
         },
         {
-          "regexp": "SC(\\d+)(\\s\\((error|warning|info|style|note)\\))?:\\s(.+)$",
-          "code": 1,
-          "severity": 3,
-          "message": 4,
+          "regexp": "(SC(\\d+)(\\s\\(\\w+\\))?:\\s.+)$",
+          "message": 1,
+          "code": 2,
           "loop": true
         }
       ]

--- a/.github/shellcheck-tty.json
+++ b/.github/shellcheck-tty.json
@@ -1,0 +1,24 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "shellcheck-tty",
+      "pattern": [
+        {
+          "regexp": "^In\\s(.+)\\sline\\s(\\d+):$",
+          "file": 1,
+          "line": 2
+        },
+        {
+          "regexp": ".*"
+        },
+        {
+          "regexp": "SC(\\d+)(\\s\\((error|warning|info|style|note)\\))?:\\s(.+)$",
+          "code": 1,
+          "severity": 3,
+          "message": 4,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -126,6 +126,9 @@ jobs:
           sudo rm -f /usr/bin/shellcheck
           # Add ~/bin to $PATH.
           echo ~/bin >> $GITHUB_PATH
+      - name: add problem matcher
+        # Show shellcheck (tty format) findings as annotations.
+        run: echo "::add-matcher::.github/shellcheck-tty.json"
       - name: run
         run: make shellcheck
       - name: check-config.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -126,7 +126,6 @@ jobs:
           sudo rm -f /usr/bin/shellcheck
           # Add ~/bin to $PATH.
           echo ~/bin >> $GITHUB_PATH
-      - uses: lumaxis/shellcheck-problem-matchers@v2
       - name: run
         run: make shellcheck
       - name: check-config.sh

--- a/script/zz-shellcheck-test.sh
+++ b/script/zz-shellcheck-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Temporary file with deliberate shellcheck issues, used to see which
+# findings (if any) GitHub annotates. NOT FOR MERGING.
+
+foo=$1
+echo $foo
+
+echo $(date)
+
+cd /tmp


### PR DESCRIPTION
Throwaway PR to check whether GitHub annotates shellcheck findings without an explicit problem matcher.

- 1st push: no matcher at all (baseline)
- 2nd push: inline `::add-matcher::` with a local matcher JSON

Do not merge.